### PR TITLE
add TokenFromContext convenience function

### DIFF
--- a/jwtauth_test.go
+++ b/jwtauth_test.go
@@ -81,26 +81,22 @@ func TestMore(t *testing.T) {
 			return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				ctx := r.Context()
 
-				if jwtErr, ok := ctx.Value("jwt.err").(error); ok {
-					switch jwtErr {
-					default:
-						http.Error(w, http.StatusText(401), 401)
-						return
-					case jwtauth.ErrExpired:
-						http.Error(w, "expired", 401)
-						return
-					case jwtauth.ErrUnauthorized:
-						http.Error(w, http.StatusText(401), 401)
-						return
-					case nil:
-						// no error
-					}
-				}
-
-				jwtToken, ok := ctx.Value("jwt").(*jwt.Token)
-				if !ok || jwtToken == nil || !jwtToken.Valid {
+				_, err := jwtauth.TokenFromContext(ctx)
+				switch err {
+				default:
 					http.Error(w, http.StatusText(401), 401)
 					return
+				case jwtauth.ErrExpired:
+					http.Error(w, "expired", 401)
+					return
+				case jwtauth.ErrUnauthorized:
+					http.Error(w, http.StatusText(401), 401)
+					return
+				case jwtauth.ErrInvalidToken:
+					http.Error(w, http.StatusText(401), 401)
+					return
+				case nil:
+					// no error
 				}
 
 				// Token is authenticated, pass it through


### PR DESCRIPTION
I've added a convenience function for retrieving a token from a given context. I was having some issues pulling the `jwtToken` from a context (was always of type `nil`), specifically this operation:

`jwtToken, ok := ctx.Value("jwt").(*jwt.Token)` 

Moving the `Authenticator` function to my own package, without edits, demonstrated the issue. Thus, I figured the easiest way to solve the problem was to create a convenience function within jwtauth to return a `jwt.Token` from a given context.

I've replaced some of  code in the `Authenticator` function and the associated test to make use of this function. I've assigned the returned `jwtToken` to the bitbucket because we don't need it (we check the error), but I think it's important for new devs to see that the function returns the token object.

All tests are passing.

Thanks for the great project, @pkieltyka! 