### PR TITLE
Implement custom search functions

### DIFF
--- a/jwtauth.go
+++ b/jwtauth.go
@@ -21,6 +21,36 @@ var (
 	ErrExpired      = errors.New("jwtauth: token is expired")
 )
 
+// An ExtractorFunc retreives the token string from the request.
+type ExtractorFunc func(r *http.Request) string
+
+var (
+	// ExtractCookie tries to retreive the token string from a cookie named "jwt".
+	ExtractCookie = func(r *http.Request) string {
+		cookie, err := r.Cookie("jwt")
+		if err != nil {
+			return ""
+		}
+		return cookie.Value
+	}
+	// ExtractHeader tries to retreive the token string from the "Authorization"
+	// reqeust header: "Authorization: BEARER T".
+	ExtractHeader = func(r *http.Request) string {
+		// Get token from authorization header.
+		bearer := r.Header.Get("Authorization")
+		if len(bearer) > 7 && strings.ToUpper(bearer[0:6]) == "BEARER" {
+			return bearer[7:]
+		}
+		return ""
+	}
+	// ExtractQuery tries to retreive the token string from the" jwt" URI query
+	// parameter.
+	ExtractQuery = func(r *http.Request) string {
+		// Get token from query param named "jwt".
+		return r.URL.Query().Get("jwt")
+	}
+)
+
 type JwtAuth struct {
 	signKey   []byte
 	verifyKey []byte
@@ -68,15 +98,15 @@ func NewWithParser(alg string, parser *jwt.Parser, signKey []byte, verifyKey []b
 // http response.
 func Verifier(ja *JwtAuth) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
-		return Verify(ja, "")(next)
+		return Verify(ja, ExtractQuery, ExtractHeader, ExtractCookie)(next)
 	}
 }
 
-func Verify(ja *JwtAuth, paramAliases ...string) func(http.Handler) http.Handler {
+func Verify(ja *JwtAuth, extractors ...ExtractorFunc) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		hfn := func(w http.ResponseWriter, r *http.Request) {
 			ctx := r.Context()
-			token, err := VerifyRequest(ja, r, paramAliases...)
+			token, err := VerifyRequest(ja, r, extractors...)
 			ctx = NewContext(ctx, token, err)
 			next.ServeHTTP(w, r.WithContext(ctx))
 		}
@@ -84,37 +114,17 @@ func Verify(ja *JwtAuth, paramAliases ...string) func(http.Handler) http.Handler
 	}
 }
 
-func VerifyRequest(ja *JwtAuth, r *http.Request, paramAliases ...string) (*jwt.Token, error) {
+func VerifyRequest(ja *JwtAuth, r *http.Request, extractors ...ExtractorFunc) (*jwt.Token, error) {
 	var tokenStr string
 	var err error
 
-	// Get token from query params
-	tokenStr = r.URL.Query().Get("jwt")
-
-	// Get token from other param aliases
-	if tokenStr == "" && paramAliases != nil && len(paramAliases) > 0 {
-		for _, p := range paramAliases {
-			tokenStr = r.URL.Query().Get(p)
-			if tokenStr != "" {
-				break
-			}
-		}
-	}
-
-	// Get token from authorization header
-	if tokenStr == "" {
-		bearer := r.Header.Get("Authorization")
-		if len(bearer) > 7 && strings.ToUpper(bearer[0:6]) == "BEARER" {
-			tokenStr = bearer[7:]
-		}
-	}
-
-	// Get token from cookie
-	if tokenStr == "" {
-		// TODO: paramAliases should apply to cookies too..
-		cookie, err := r.Cookie("jwt")
-		if err == nil {
-			tokenStr = cookie.Value
+	// Extract token string from the request by calling extractors in the order
+	// they where provided. Further extraction stops if an extractor returns a
+	// non-empty string.
+	for _, extractor := range extractors {
+		tokenStr = extractor(r)
+		if tokenStr != "" {
+			break
 		}
 	}
 

--- a/jwtauth.go
+++ b/jwtauth.go
@@ -96,7 +96,7 @@ func NewWithParser(alg string, parser *jwt.Parser, signKey []byte, verifyKey []b
 // http response.
 func Verifier(ja *JwtAuth) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
-		return Verify(ja, TokenFromCookie, TokenFromHeader, TokenFromQuery)(next)
+		return Verify(ja, TokenFromQuery, TokenFromHeader, TokenFromCookie)(next)
 	}
 }
 


### PR DESCRIPTION
I think there are many ways to implement the configuration proposal I made in #19. I made up this draft for the following reason:

The jwtauth package has two main components used by package users: The `Verifier` and the `Authenticator` functions. Implementing a custom `Authenticator` is easy because the provided one is ~10 lines of code. But implementing a custom `Verifier` is a little bit trickier because this is where the token gets extracted from the request, validated, etc. 

So instead of adding more function parameters or a custom options struct, I came up with this PR which adds so called `Extractors`. What sounds complicated is pretty easy: Instead of hard coding where the `Verifier` searches for the token string in the request, we provide it with `ExtractorFunc`s that do this task for the `Verifier`. Furthermore, the signature of the original `Verifier` function has not been changed, so there won't be any breaking changes for users relaying  on the default behaviour of this package.

What got removed are the `params`. But I don't think that's critical. They can be replaced by implementing a custom `ExtractorFunc`.

Furthermore there was no need to adjust the tests.

So what got added in this PR?
* `ExtractorFunc` type
* Three extractors (functions): JWT Cookie, Authroization Header, JWT query param

I think it's best if @pkieltyka or another maintainer takes a look at the code and provides me with some feedback.