### PR TITLE
Truly support jwtauth.Claims when parsing from context

### DIFF
--- a/jwtauth.go
+++ b/jwtauth.go
@@ -194,7 +194,7 @@ func FromContext(ctx context.Context) (*jwt.Token, Claims, error) {
 	if token != nil {
 		switch tokenClaims := token.Claims.(type) {
 		case Claims:
-			// Nop.
+			claims = tokenClaims
 		case jwt.MapClaims:
 			claims = Claims(tokenClaims)
 		default:


### PR DESCRIPTION
Previous change "fixed" the panic, but would silently remove all Claims,
because the tokenClaims are not copied over to the claims variable.