### PR TITLE
Allow specify custom keyFunc & flexible costructor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 language: go
 
 go:
-  - 1.7.x
-  - 1.8.x
+  - 1.9.x
+  - 1.10.x
+  - 1.11.x
   - tip
 
 install:

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,6 @@
 module github.com/go-chi/jwtauth
 
-require github.com/dgrijalva/jwt-go v3.2.0+incompatible
+require (
+	github.com/dgrijalva/jwt-go v3.2.0+incompatible
+	github.com/go-chi/chi v3.3.3+incompatible
+)

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,4 @@
 github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
+github.com/go-chi/chi v3.3.3+incompatible h1:KHkmBEMNkwKuK4FdQL7N2wOeB9jnIx7jR5wsuSBEFI8=
+github.com/go-chi/chi v3.3.3+incompatible/go.mod h1:eB3wogJHnLi3x/kFX2A+IbTBlXxmMeXJVKy9tTv1XzQ=

--- a/jwtauth.go
+++ b/jwtauth.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/dgrijalva/jwt-go"
+	jwt "github.com/dgrijalva/jwt-go"
 )
 
 // Context keys

--- a/jwtauth_test.go
+++ b/jwtauth_test.go
@@ -13,7 +13,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/dgrijalva/jwt-go"
+	jwt "github.com/dgrijalva/jwt-go"
 	"github.com/go-chi/chi"
 	"github.com/go-chi/jwtauth"
 )

--- a/jwtauth_test.go
+++ b/jwtauth_test.go
@@ -230,7 +230,7 @@ func TestMore(t *testing.T) {
 		t.Fatalf(resp)
 	}
 
-	h = newAuthHeader((jwt.MapClaims{"user_id": 31337, "exp": jwtauth.ExpireIn(5 * time.Minute)}))
+	h = newAuthHeader(jwt.MapClaims{"user_id": 31337, "exp": jwtauth.ExpireIn(5 * time.Minute)})
 	if status, resp := testRequest(t, ts, "GET", "/admin", h, nil); status != 200 || resp != "protected, user:31337" {
 		t.Fatalf(resp)
 	}

--- a/options.go
+++ b/options.go
@@ -1,7 +1,7 @@
 package jwtauth
 
 import (
-	"github.com/dgrijalva/jwt-go"
+	jwt "github.com/dgrijalva/jwt-go"
 )
 
 type Option func(ja *JWTAuth)

--- a/options.go
+++ b/options.go
@@ -1,0 +1,31 @@
+package jwtauth
+
+import (
+	"github.com/dgrijalva/jwt-go"
+)
+
+type Option func(ja *JWTAuth)
+
+func WithSignKey(key interface{}) Option {
+	return func(ja *JWTAuth) {
+		ja.signKey = key
+	}
+}
+
+func WithVerifyKey(key interface{}) Option {
+	return func(ja *JWTAuth) {
+		ja.verifyKey = key
+	}
+}
+
+func WithCustomParser(parser *jwt.Parser) Option {
+	return func(ja *JWTAuth) {
+		ja.parser = parser
+	}
+}
+
+func WithCustomKeyFunc(fn jwt.Keyfunc) Option {
+	return func(ja *JWTAuth) {
+		ja.customKeyFunc = fn
+	}
+}

--- a/options_test.go
+++ b/options_test.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/dgrijalva/jwt-go"
+	jwt "github.com/dgrijalva/jwt-go"
 )
 
 func TestNewWithOptions(t *testing.T) {

--- a/options_test.go
+++ b/options_test.go
@@ -1,0 +1,44 @@
+package jwtauth
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+
+	"github.com/dgrijalva/jwt-go"
+)
+
+func TestNewWithOptions(t *testing.T) {
+	const alg = "RS256"
+	testErr := errors.New("jwtauth test error")
+	key1 := []byte("key1")
+	key2 := []byte("key2")
+	keyFunc := func(t *jwt.Token) (interface{}, error) {
+		return nil, testErr
+	}
+	parser := jwt.Parser{}
+
+	ja1 := NewWithOptions(alg)
+	if ja1.parser == nil {
+		t.Fatal("Parser not set!")
+	}
+
+	ja2 := NewWithOptions(alg, WithSignKey(key1), WithVerifyKey(key2),
+		WithCustomParser(&parser), WithCustomKeyFunc(keyFunc))
+
+	if key, _ := ja2.signKey.([]byte); key == nil || !bytes.Equal(key, key1) {
+		t.Fatal("SignKey not set or set incorrectly!", key, key1)
+	}
+
+	if key, _ := ja2.verifyKey.([]byte); key == nil || !bytes.Equal(key, key2) {
+		t.Fatal("VerifyKey not set or set incorrectly!", key, key2)
+	}
+
+	if ja2.parser != &parser {
+		t.Fatal("Parser not set or set incorrectly!")
+	}
+
+	if _, err := ja2.keyFunc(nil); err != testErr {
+		t.Fatal("CustomKeyFunc not set or set incorrectly!")
+	}
+}


### PR DESCRIPTION
NewWithOptions() constructor added with support of custom keyFunc option and suitable for future new options without new `New...` methods.

I using it for myself to implement Auth0 integration with custom `KeyFunc` as described [here](https://github.com/auth0-samples/auth0-golang-api-samples)