### PR TITLE
Claim creation issue in the example

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,6 @@ package main
 import (
 	"fmt"
 	"net/http"
-
 	"github.com/go-chi/chi"
 	"github.com/go-chi/jwtauth"
 )
@@ -65,7 +64,7 @@ func init() {
 
 	// For debugging/example purposes, we generate and print
 	// a sample jwt token with claims `user_id:123` here:
-	_, tokenString, _ := tokenAuth.Encode(jwt.MapClaims{"user_id": 123})
+	_, tokenString, _ := tokenAuth.Encode(jwtauth.Claims{"user_id": 123})
 	fmt.Printf("DEBUG: a sample jwt is %s\n\n", tokenString)
 }
 


### PR DESCRIPTION
In the example, the Claims is created using `jwt.MapClaims`. It should be `jwtauth.Claims`. Thus, the codes in `init()` should be as follows:
```
tokenAuth = jwtauth.New("HS256", []byte("secret"), nil)
...
_, tokenString, _ := tokenAuth.Encode(jwtauth.Claims{"user_id": 123})
fmt.Printf("DEBUG: a sample jwt is %s\n\n", tokenString)
```