### PR TITLE
fix: Corrected compile error -> "cannot use jwt.MapClaims literal (type jwt.MapClaims) as type jwtauth.Claims"

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ func init() {
 
 	// For debugging/example purposes, we generate and print
 	// a sample jwt token with claims `user_id:123` here:
-	_, tokenString, _ := tokenAuth.Encode(jwt.MapClaims{"user_id": 123})
+	_, tokenString, _ := tokenAuth.Encode(jwtauth.Claims{"user_id": 123})
 	fmt.Printf("DEBUG: a sample jwt is %s\n\n", tokenString)
 }
 


### PR DESCRIPTION
Using github.com/go-chi/jwtauth v3.3.0+incompatible