### PR TITLE
Add TokenFromRequest helper function

### DIFF
--- a/jwtauth.go
+++ b/jwtauth.go
@@ -241,6 +241,23 @@ func SetExpiryIn(claims map[string]interface{}, tm time.Duration) {
 	claims["exp"] = ExpireIn(tm)
 }
 
+var tokenRetreivers = []func(r *http.Request) string{
+	TokenFromHeader,
+	TokenFromQuery,
+}
+
+// TokenFromRequest tries to retreive the token string from all supported methods:
+// TokenFromHeader and TokenFromQuery in same order
+func TokenFromRequest(r *http.Request) string {
+	for i := range tokenRetreivers {
+		if token := tokenRetreivers[i](r); token != "" {
+			return token
+		}
+	}
+
+	return ""
+}
+
 // TokenFromCookie tries to retreive the token string from a cookie named
 // "jwt".
 func TokenFromCookie(r *http.Request) string {


### PR DESCRIPTION
`TokenFromRequest` will use `TokenFromHeader` and `TokenFromQuery` in the same order to get jwt token from a request.