### PR TITLE
add WithParseOption() to create jwtauth with custom parse options

### DIFF
--- a/jwtauth.go
+++ b/jwtauth.go
@@ -44,6 +44,10 @@ func New(alg string, signKey interface{}, verifyKey interface{}) *JWTAuth {
 	return ja
 }
 
+func WithParseOption(alg string, verifier jwt.ParseOption) *JWTAuth {
+	return &JWTAuth{alg: jwa.SignatureAlgorithm(alg), verifier: verifier}
+}
+
 // Verifier http middleware handler will verify a JWT string from a http request.
 //
 // Verifier will search for a JWT token in a http request, in the order:


### PR DESCRIPTION
Hello, 

This PR adds the new function `WithParseOption()`, which allows specifying custom parse options for `JWTAuth`.
This enables specifying custom options such as `jwt.WithKeySetProvider`, which allows us to use JWKS and more sophisticated validation logic.

See also related #59, #40, #27. We should be able to resolve most of the mentioned issues here with these custom options.

Thanks a lot, let me know if you have any further feedback!