### PR TITLE
Authenticator: remove jwt.Validate

### DIFF
--- a/jwtauth.go
+++ b/jwtauth.go
@@ -178,7 +178,7 @@ func Authenticator(ja *JWTAuth) func(http.Handler) http.Handler {
 				return
 			}
 
-			if token == nil || jwt.Validate(token, ja.validateOptions...) != nil {
+			if token == nil {
 				http.Error(w, http.StatusText(http.StatusUnauthorized), http.StatusUnauthorized)
 				return
 			}


### PR DESCRIPTION
jwt.Validate is already called in [Verifier](https://github.com/go-chi/jwtauth/blob/1ff608193a049433794670a8c18fd739c5b2f236/jwtauth.go#L114), no need to call it twice.

If jwt.Validate fails in `Verifier`, the error is set in the `context` and the Authenticator retrieves the token and error from the `context`.