### PR TITLE
Fix invalid Bearer prefix format (wrong character instead of a space)

### DIFF
--- a/jwtauth.go
+++ b/jwtauth.go
@@ -268,7 +268,7 @@ func TokenFromCookie(r *http.Request) string {
 func TokenFromHeader(r *http.Request) string {
 	// Get token from authorization header.
 	bearer := r.Header.Get("Authorization")
-	if len(bearer) > 7 && strings.ToUpper(bearer[0:6]) == "BEARER" {
+	if len(bearer) > 7 && strings.ToUpper(bearer[0:7]) == "BEARER " {
 		return bearer[7:]
 	}
 	return ""

--- a/jwtauth_test.go
+++ b/jwtauth_test.go
@@ -84,6 +84,8 @@ func TestSimple(t *testing.T) {
 		{Name: "valid BEARER", Authorization: "BEARER " + newJwtToken(TokenSecret), Status: 200, Resp: "welcome"},
 		{Name: "valid bearer", Authorization: "bearer " + newJwtToken(TokenSecret), Status: 200, Resp: "welcome"},
 		{Name: "valid claim", Authorization: "Bearer " + newJwtToken(TokenSecret, map[string]interface{}{"service": "test"}), Status: 200, Resp: "welcome"},
+		{Name: "invalid bearer_", Authorization: "BEARER_" + newJwtToken(TokenSecret), Status: 401, Resp: "token is unauthorized\n"},
+		{Name: "invalid bearerx", Authorization: "BEARERx" + newJwtToken(TokenSecret), Status: 401, Resp: "token is unauthorized\n"},
 	}
 
 	for _, tc := range tt {
@@ -93,7 +95,7 @@ func TestSimple(t *testing.T) {
 		}
 		status, resp := testRequest(t, ts, "GET", "/", h, nil)
 		if status != tc.Status || resp != tc.Resp {
-			t.Fatalf("test '%s' failed: expected status %d, got %d", tc.Name, tc.Status, status)
+			t.Errorf("test '%s' failed: expected Status: %d %q, got %d %q", tc.Name, tc.Status, tc.Resp, status, resp)
 		}
 	}
 }

--- a/jwtauth_test.go
+++ b/jwtauth_test.go
@@ -84,8 +84,8 @@ func TestSimple(t *testing.T) {
 		{Name: "valid BEARER", Authorization: "BEARER " + newJwtToken(TokenSecret), Status: 200, Resp: "welcome"},
 		{Name: "valid bearer", Authorization: "bearer " + newJwtToken(TokenSecret), Status: 200, Resp: "welcome"},
 		{Name: "valid claim", Authorization: "Bearer " + newJwtToken(TokenSecret, map[string]interface{}{"service": "test"}), Status: 200, Resp: "welcome"},
-		{Name: "invalid bearer_", Authorization: "BEARER_" + newJwtToken(TokenSecret), Status: 401, Resp: "token is unauthorized\n"},
-		{Name: "invalid bearerx", Authorization: "BEARERx" + newJwtToken(TokenSecret), Status: 401, Resp: "token is unauthorized\n"},
+		{Name: "invalid bearer_", Authorization: "BEARER_" + newJwtToken(TokenSecret), Status: 401, Resp: "no token found\n"},
+		{Name: "invalid bearerx", Authorization: "BEARERx" + newJwtToken(TokenSecret), Status: 401, Resp: "no token found\n"},
 	}
 
 	for _, tc := range tt {


### PR DESCRIPTION
Disallow invalid headers like `"Authorization: BEARERx{JWT}"` (notice the `x` character instead of a space).

- **Rewrite simple tests to table-driven tests**
- **Add tests cases for invalid Bearer prefixes**
- **Disallow invalid character after BEARER prefix**

Fixes https://github.com/go-chi/jwtauth/issues/98
